### PR TITLE
Fix initial SAML request and SLO

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,52 @@
 GIT
   remote: https://github.com/18F/identity-hostdata.git
-  revision: 96c08e8ea8c58cdde45de62d0f269c8b19bf1724
+  revision: 4340185470fdf07c5d06658c2aa5ce6c904bb898
   branch: master
   specs:
     identity-hostdata (0.3.2)
-      aws-sdk-core (~> 2.10.23)
+      aws-sdk-s3 (~> 1.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk-core (2.10.54)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.104.0)
+    aws-sdk-core (3.27.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sigv4 (1.0.2)
-    hashie (3.5.7)
-    jmespath (1.3.1)
+    aws-sdk-kms (1.9.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.20.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
+    hashie (3.6.0)
+    jmespath (1.4.0)
     metaclass (0.0.4)
     mini_portile2 (2.3.0)
-    mocha (1.5.0)
+    mocha (1.7.0)
       metaclass (~> 0.0.1)
-    mustermann (1.0.2)
-    nokogiri (1.8.2)
+    mustermann (1.0.3)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    power_assert (1.1.1)
-    rack (2.0.4)
-    rack-protection (2.0.1)
+    power_assert (1.1.3)
+    rack (2.0.5)
+    rack-protection (2.0.4)
       rack
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    ruby-saml (1.7.2)
+    ruby-saml (1.9.0)
       nokogiri (>= 1.5.10)
-    sinatra (2.0.1)
+    sinatra (2.0.4)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.4)
       tilt (~> 2.0)
-    test-unit (3.2.7)
+    test-unit (3.2.8)
       power_assert
     tilt (2.0.8)
 

--- a/config/saml_settings.yml
+++ b/config/saml_settings.yml
@@ -23,7 +23,7 @@ idp_cert_fingerprint: 8B:D5:C2:E8:9A:2B:CE:B7:4B:95:50:BA:16:79:05:27:17:D1:D3:6
 <% end %>
 
 assertion_consumer_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
-name_identifier_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+name_identifier_format: urn:oasis:names:tc:SAML:1.1:nameid-format:persistent
 authn_context: http://idmanagement.gov/ns/assurance/loa/1
 single_signon_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 allowed_clock_drift: 60


### PR DESCRIPTION
**Why**: This app was requesting the email as the nameID, but the IdP
app only allows certain SPs to use email as opposed to UUID.
IdP-initiated SLO was also broken.

**How**:
- Use `persistent` for the nameID
- Use the same SLO code as in identity-saml-rails