### PR TITLE
Fetch yearly SAML cert dynamically from S3.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 
 ruby '~> 2.3.5'
 
+gem 'aws-sdk-s3', '~> 1.30'
 gem 'hashie'
 gem 'mocha'
 gem 'ruby-saml'
@@ -10,3 +11,7 @@ gem 'rack-test'
 gem 'sinatra'
 gem 'test-unit'
 gem 'identity-hostdata', github: '18F/identity-hostdata', branch: 'master'
+
+group :development do
+  gem 'pry'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,31 +10,36 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.0.1)
-    aws-partitions (1.104.0)
-    aws-sdk-core (3.27.0)
+    aws-partitions (1.142.0)
+    aws-sdk-core (3.46.2)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.9.0)
-      aws-sdk-core (~> 3, >= 3.26.0)
+    aws-sdk-kms (1.13.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.20.0)
-      aws-sdk-core (~> 3, >= 3.26.0)
+    aws-sdk-s3 (1.30.1)
+      aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
+    coderay (1.1.2)
     hashie (3.6.0)
     jmespath (1.4.0)
     metaclass (0.0.4)
-    mini_portile2 (2.3.0)
+    method_source (0.9.2)
+    mini_portile2 (2.4.0)
     mocha (1.7.0)
       metaclass (~> 0.0.1)
     mustermann (1.0.3)
-    nokogiri (1.8.4)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     power_assert (1.1.3)
-    rack (2.0.5)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    rack (2.0.6)
     rack-protection (2.0.4)
       rack
     rack-test (1.1.0)
@@ -54,9 +59,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1.30)
   hashie
   identity-hostdata!
   mocha
+  pry
   rack-test
   ruby-saml
   sinatra
@@ -66,4 +73,4 @@ RUBY VERSION
    ruby 2.3.5p376
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/identity-hostdata.git
-  revision: 4340185470fdf07c5d06658c2aa5ce6c904bb898
+  revision: b5587588601670f762bbc79f0f4a8468064d9401
   branch: master
   specs:
-    identity-hostdata (0.3.2)
+    identity-hostdata (0.3.3)
       aws-sdk-s3 (~> 1.8)
 
 GEM

--- a/app.rb
+++ b/app.rb
@@ -107,8 +107,17 @@ class RelyingParty < Sinatra::Base
   def saml_settings
     template = File.read('config/saml_settings.yml')
     base_config = Hashie::Mash.new(YAML.safe_load(ERB.new(template).result(binding)))
+
+    # TODO: don't use the demo cert and key in EC2 environments
+    if LoginGov::Hostdata.in_datacenter? && (
+      LoginGov::Hostdata.domain == 'login.gov' ||
+      LoginGov::Hostdata.env == 'prod'
+    )
+      raise NotImplementedError.new('Refusing to use demo cert in production')
+    end
     base_config.certificate = File.read('config/demo_sp.crt')
     base_config.private_key = File.read('config/demo_sp.key')
+
     OneLogin::RubySaml::Settings.new(base_config)
   end
 

--- a/config/saml_settings.yml
+++ b/config/saml_settings.yml
@@ -1,7 +1,6 @@
 ---
 <%
 require 'aws-sdk-s3'
-require 'aws-sdk-sts'
 require 'digest/sha1'
 require 'login_gov/hostdata'
 require 'openssl'
@@ -17,11 +16,17 @@ if LoginGov::Hostdata.in_datacenter?
   # Rotate this annually
   year_suffix = '2019'
 
+  # Get EC2 metadata so we can discover region and account ID
+  ec2 = LoginGov::Hostdata::EC2.load
+
   # Fetch the IDP SAML cert from S3
-  aws_account_id = Aws::STS::Client.new.get_caller_identity.account
-  bucket_name = "login-gov.secrets.#{aws_account_id}-us-west-2"
+  bucket_name = "login-gov.secrets.#{ec2.account_id}-#{ec2.region}"
   s3_key = "#{LoginGov::Hostdata.env}/saml#{year_suffix}.crt"
-  s3 = Aws::S3::Client.new
+  s3 = Aws::S3::Client.new(
+    region: ec2.region,
+    http_open_timeout: 5,
+    http_read_timeout: 5
+  )
   resp = s3.get_object(bucket: bucket_name, key: s3_key)
 
   idp_saml_cert = OpenSSL::X509::Certificate.new(resp.body.read)

--- a/config/saml_settings.yml
+++ b/config/saml_settings.yml
@@ -1,20 +1,46 @@
-<% if LoginGov::Hostdata.in_datacenter? %>
+---
 <%
+require 'aws-sdk-s3'
+require 'aws-sdk-sts'
+require 'digest/sha1'
+require 'login_gov/hostdata'
+require 'openssl'
+
+if LoginGov::Hostdata.in_datacenter?
   idp_host = case LoginGov::Hostdata.env
              when 'prod'
                "secure.#{LoginGov::Hostdata.domain}"
              else
                "idp.#{LoginGov::Hostdata.env}.#{LoginGov::Hostdata.domain}"
              end
+
+  # Rotate this annually
+  year_suffix = '2019'
+
+  # Fetch the IDP SAML cert from S3
+  aws_account_id = Aws::STS::Client.new.get_caller_identity.account
+  bucket_name = "login-gov.secrets.#{aws_account_id}-us-west-2"
+  s3_key = "#{LoginGov::Hostdata.env}/saml#{year_suffix}.crt"
+  s3 = Aws::S3::Client.new
+  resp = s3.get_object(bucket: bucket_name, key: s3_key)
+
+  idp_saml_cert = OpenSSL::X509::Certificate.new(resp.body.read)
+  idp_saml_cert_fingerprint = Digest::SHA1.hexdigest(idp_saml_cert.to_der).scan(/../).join(':').upcase
 %>
-assertion_consumer_service_url: https://sp-sinatra.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/consume
-issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:<%= LoginGov::Hostdata.env %>
-idp_sso_target_url: https://<%= idp_host %>/api/saml/auth
-idp_slo_target_url: https://<%= idp_host %>/api/saml/logout
-# 68:19:... is the fingerprint of the SAML IDP cert CN=int.login.gov
-# Serial: 0xf41d6ee2e4675981, Issued: July 11 2017, Expires: July 11 2018
-idp_cert_fingerprint: 68:19:E0:CB:D2:44:A0:CD:B7:D1:80:8A:E2:34:E4:22:90:41:DF:10
+# Config for EC2 environments
+assertion_consumer_service_url: "https://sp-sinatra.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/consume"
+issuer: "urn:gov:gsa:SAML:2.0.profiles:sp:sso:<%= LoginGov::Hostdata.env %>"
+idp_sso_target_url: "https://<%= idp_host %>/api/saml/auth<%= year_suffix %>"
+idp_slo_target_url: "https://<%= idp_host %>/api/saml/logout<%= year_suffix %>"
+idp_cert_fingerprint: "<%= idp_saml_cert_fingerprint %>"
+# Cert info:
+#   year_suffix: <%= year_suffix %>
+#   not_before: <%= idp_saml_cert.not_before.to_date %>
+#   not_after: <%= idp_saml_cert.not_after.to_date %>
+#   s3_path: s3://<%= bucket_name %>/<%= s3_key %>
+
 <% else %>
+# Config for local development
 assertion_consumer_service_url: http://localhost:4567/consume
 issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost
 idp_sso_target_url: http://localhost:3000/api/saml/auth
@@ -33,3 +59,5 @@ security:
   embed_sign: true
   digest_method: http://www.w3.org/2001/04/xmlenc#sha256
   signature_method: http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
+
+# vim: set ft=eruby :


### PR DESCRIPTION
- Instead of hardcoding the IDP SAML certificate fingerprint, fetch the
  certificate for the given year from S3, the same place where the IDP
  loads it from. At some point if we move to using AWS Secrets Manager,
  we'll want to move to that instead.
  Another way to handle this would've been to hit the IDP metadata URL,
  but that would involve parsing XML (yuck).
- Add a guard against ever using the demo certificate + key in a
  production environment. Right now the demo key is hardcoded and used
  everywhere.

Also upgrade vulnerable rack and nokogiri gems.