### PR TITLE
LG-1906: logging to /srv/sp-saml-sinatra/shared/log/production.log when deployed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     mocha (1.7.0)
       metaclass (~> 0.0.1)
     mustermann (1.0.3)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     power_assert (1.1.3)
     pry (0.12.2)

--- a/app.rb
+++ b/app.rb
@@ -10,6 +10,15 @@ require 'yaml'
 class RelyingParty < Sinatra::Base
   use Rack::Session::Cookie, key: 'sinatra_sp', secret: SecureRandom.uuid
 
+  if LoginGov::Hostdata.in_datacenter?
+    configure do
+      enable :logging
+      file = File.new("/srv/sp-saml-sinatra/shared/log/production.log", 'a+')
+      file.sync = true
+      use Rack::CommonLogger, file
+    end
+  end
+
   def init(uri)
     @auth_server_uri = uri
   end


### PR DESCRIPTION
*Why?* Can't check the logs to see what is happening if the logs don't exist!