### PR TITLE
LG-2691: Variable IAL level

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 export issuer=urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost
 export assertion_consumer_service_url=http://localhost:4567/consume
-export idp_sso_target_url=http://localhost:3000/api/saml/auth
-export idp_slo_target_url=http://localhost:3000/api/saml/logout
+export idp_sso_target_url=http://localhost:3000/api/saml/auth2018
+export idp_slo_target_url=http://localhost:3000/api/saml/logout2018
 export idp_host=localhost:3000
-export idp_cert_fingerprint=BD:21:A9:57:14:3C:A8:4F:3F:C5:E6:99:7F:97:F6:E4:7E:E7:1D:1F
+export idp_cert_fingerprint=F9:D7:61:2A:11:F6:C2:74:B0:47:01:3B:B6:79:B1:53:11:C7:82:4C

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-setup:
+.env: .env.example
+	cp -n .env.example .env
+
+setup: .env
 	bundle install
 
 test:

--- a/app.rb
+++ b/app.rb
@@ -95,7 +95,7 @@ class RelyingParty < Sinatra::Base
     agency = session[:agency]
     puts "Success!"
     if !agency.nil?
-      erb :"agency/#{agency}/success", :layout => false
+      erb :"agency/#{agency}/success", layout: false
     else
       session[:login] = 'ok'
       redirect to('/')
@@ -114,6 +114,8 @@ class RelyingParty < Sinatra::Base
     if response.is_valid?
       session[:userid] = user_uuid
       session[:email] = response.attributes['email']
+      session[:attributes] = response.attributes.to_h.to_json
+
       puts 'SAML Success!'
       redirect to('/success')
     else
@@ -128,6 +130,7 @@ class RelyingParty < Sinatra::Base
   def logout_session
     session.delete(:userid)
     session.delete(:email)
+    session.delete(:attributes)
   end
 
   def home_page
@@ -211,6 +214,10 @@ class RelyingParty < Sinatra::Base
     settings.name_identifier_value = session[:user_id]
     logout_request = OneLogin::RubySaml::Logoutrequest.new.create(settings)
     redirect to(logout_request)
+  end
+
+  def maybe_redact_ssn(ssn)
+    ssn&.gsub(/\d/, '#')
   end
 
   run! if app_file == $0

--- a/app.rb
+++ b/app.rb
@@ -38,8 +38,18 @@ class RelyingParty < Sinatra::Base
       session[:agency] = agency
       erb :"agency/#{agency}/index", layout: false, locals: { logout_msg: logout_msg }
     else
+      ial = params[:ial] || '1'
+      ial1_link_class = 'text-underline' if ial == '1'
+      ial2_link_class = 'text-underline' if ial == '2'
+
       session.delete(:agency)
-      erb :index, locals: { logout_msg: logout_msg, login_msg: login_msg }
+      erb :index, locals: {
+        logout_msg: logout_msg,
+        login_msg: login_msg,
+        login_path: "/login_get?ial=#{ial}",
+        ial1_link_class: ial1_link_class,
+        ial2_link_class: ial2_link_class,
+      }
     end
   end
 
@@ -47,15 +57,18 @@ class RelyingParty < Sinatra::Base
     puts "Logging in via GET"
     request = OneLogin::RubySaml::Authrequest.new
     puts "Request: #{request}"
-    redirect to(request.create(saml_settings))
+    ial = params[:ial] || '1'
+    redirect to(request.create(saml_settings(ial: ial)))
   end
 
   post '/login_post/?' do
     puts "Logging in via POST"
     saml_request = OneLogin::RubySaml::Authrequest.new
     puts "Request: #{saml_request}"
-    post_params = saml_request.create_params(saml_settings, 'RelayState' => params[:id])
-    login_url   = saml_settings.idp_sso_target_url
+    ial = params[:ial] || '1'
+    settings = saml_settings(ial: ial)
+    post_params = saml_request.create_params(settings, 'RelayState' => params[:id])
+    login_url   = settings.idp_sso_target_url
     erb :login_post, locals: { login_url: login_url, post_params: post_params }
   end
 
@@ -125,9 +138,11 @@ class RelyingParty < Sinatra::Base
     end
   end
 
-  def saml_settings
+  def saml_settings(ial: nil)
     template = File.read('config/saml_settings.yml')
     base_config = Hashie::Mash.new(YAML.safe_load(ERB.new(template).result(binding)))
+
+    base_config.authn_context = "http://idmanagement.gov/ns/assurance/ial/#{ial}" if ial
 
     # TODO: don't use the demo cert and key in EC2 environments
     if LoginGov::Hostdata.in_datacenter? && (

--- a/public/assets/css/fake.css
+++ b/public/assets/css/fake.css
@@ -51,3 +51,21 @@
   margin-top: 20px;
   margin-left: 10px;
 }
+
+.userinfo {
+  border: 1px solid black;
+  color: #000000;
+  font-size: 0.6em;
+  margin-top: .5rem;
+  position: absolute;
+  right: 360px;
+  top: 285px;
+}
+.userinfo pre {
+  margin: 0;
+}
+@media (max-width: 63.99em) {
+  .userinfo {
+    position: initial;
+  }
+}

--- a/views/index.erb
+++ b/views/index.erb
@@ -119,6 +119,25 @@
           </form>
         <% end %>
       </div>
+
+      <% if session[:attributes] %>
+        <% userinfo = JSON.parse(session[:attributes]) %>
+        <div class="userinfo">
+          <div class="p2 clearfix bg-white fg-black">
+            <span>Received user info:</span>
+            <ul>
+              <% userinfo.each_pair do |key, vals| %>
+                <li><code><%= key.inspect %>:
+                  <% vals.each do |val| %>
+                    <% val = maybe_redact_ssn(val) if key.to_s == 'ssn' %>
+                    <%= val.inspect %>
+                  <% end %>
+                </code></li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
     </div>
   </section>
   <section class="grid-container usa-section">

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,6 +1,6 @@
 <a class="usa-skipnav" href="#main-content">Skip to main content</a>
 <div class="py1 bg-maroon white fs-12p line-height-1 center">
-  TEST SITE - Do not use real personal information (demo purposes only) - TEST SITE
+  TEST Do not use real personal information (demo purposes only) TEST
 </div>
 <div class="py1 bg-navy white fs-12p line-height-1 center">
   <img class="mr1 align-bottom" src="/assets/img/us-flag.png" alt="U.S. flag" width="18" height="12">
@@ -74,21 +74,21 @@
             </div>
           </div>
         <% else %>
+          <ul class="usa-nav__secondary-links sign-in-type-wrap">
+            <li class="usa-nav__secondary-item">
+              <a href="?ial=1"><span class="<%= ial1_link_class %>">IAL1</span></a>
+            </li>
+            <li class="usa-nav__secondary-item">
+              <a href="?ial=2"><span class="<%= ial2_link_class %>">IAL2</span></a>
+            </li>
+          </ul>
           <div class="sign-in-wrap">
-            <form action="/login_get" method="POST">
-              <button type="submit"  class="usa-button usa-button--outline sign-in-bttn" style="float:right">
+            <form action="<%= login_path %>" method="POST" style="float:right">
+              <button type="submit"  class="usa-button usa-button--outline sign-in-bttn">
                 <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                   <path fill="currentColor" d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"></path>
                 </svg>
-                Sign in via GET
-              </button>
-            </form>
-            <form action="/login_post" method="POST">
-              <button type="submit"  class="usa-button usa-button--outline sign-in-bttn" style="float:right">
-                <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-                  <path fill="currentColor" d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"></path>
-                </svg>
-                Sign in via POST
+                Sign in
               </button>
             </form>
           </div>


### PR DESCRIPTION
Updates the app to match the OIDC example with configurable IAL level

Having some trouble testing with the IDP locally

I needed up update the IDP with this config to allow this to do IAL 2:

```diff
identity-idp:master> colordiff -C 3 config/service_providers.{localdev.,}yml        
*** config/service_providers.localdev.yml	2020-03-18 11:15:15.000000000 -0700
--- config/service_providers.yml	2020-04-09 12:11:48.000000000 -0700
***************
*** 232,239 ****
--- 232,244 ----
      block_encryption: 'aes256-cbc'
      cert: 'sp_sinatra_demo'
      ial: 2
+     active: true
      attribute_bundle:
        - email
+       - first_name
+       - last_name
+       - ssn
+       - zipcode
  
    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase':
      acs_url: 'http://localhost:3000/auth/saml/callback'
```