### PR TITLE
LG-3099: allow sample SP to request aal authn context

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,4 +77,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/config/saml_settings.yml
+++ b/config/saml_settings.yml
@@ -7,7 +7,7 @@ idp_cert_fingerprint: <%= ENV['idp_cert_fingerprint'] %>
 
 assertion_consumer_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 name_identifier_format: urn:oasis:names:tc:SAML:1.1:nameid-format:persistent
-authn_context: http://idmanagement.gov/ns/assurance/loa/1
+ial_context: http://idmanagement.gov/ns/assurance/ial/1
 single_signon_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 allowed_clock_drift: 60
 security:


### PR DESCRIPTION
This PR allows the addition of the url param `aal=3`to be set so the sample app can be used to test out SAML requests for AAL3 authentication.