### PR TITLE
LG-3859: New option to skip encryption of SAML response

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -129,7 +129,7 @@
                   </label>
                   <select name="skip_encryption" id="skip_encryption" class="usa-select">
                     <% [
-                      [nil, 'Do Encryption'],
+                      [nil, 'With Encryption'],
                       ['true', 'Skip encryption'],
                     ].each do |value, label| %>
                       <option value="<%= value %>"

--- a/views/index.erb
+++ b/views/index.erb
@@ -92,9 +92,18 @@
                     Authentication Assurance Level (AAL)
                   </label>
                   <select name="aal" id="aal" class="usa-select">
-                    <option value="">Default</option>
-                    <option value="3">AAL 3</option>
-                    <option value="3-hspd12">HSPD12 required</option>
+                    <% [
+                      ['1', 'AAL 1 (Default)'],
+                      ['2', 'AAL 2'],
+                      ['3', 'AAL 3'],
+                      ['3-hspd12', 'HSPD12 required'],
+                    ].each do |value, label| %>
+                      <option value="<%= value %>"
+                              <%= 'selected="true"' if aal == value %>
+                              >
+                        <%= label %>
+                      </option>
+                    <% end %>
                   </select>
 
                   <label class="usa-label" for="ial">
@@ -109,6 +118,22 @@
                     ].each do |value, label| %>
                       <option value="<%= value %>"
                               <%= 'selected="true"' if ial == value %>
+                              >
+                        <%= label %>
+                      </option>
+                    <% end %>
+                  </select>
+
+                  <label class="usa-label" for="skip_encryption">
+                    Skip Encryption
+                  </label>
+                  <select name="skip_encryption" id="skip_encryption" class="usa-select">
+                    <% [
+                      [nil, 'Do Encryption'],
+                      ['true', 'Skip encryption'],
+                    ].each do |value, label| %>
+                      <option value="<%= value %>"
+                              <%= 'selected="true"' if skip_encryption == value %>
                               >
                         <%= label %>
                       </option>


### PR DESCRIPTION
Adds an option to skip the encryption of the SAML response. In conjunction with https://github.com/18F/identity-idp/pull/4503