### PR TITLE
Enable the cert and key to be configured via env vars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'rack-test'
 gem 'rake'
 gem 'sinatra'
 gem 'test-unit'
-gem 'identity-hostdata', github: '18F/identity-hostdata', branch: 'master'
 gem 'activesupport'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/18F/identity-hostdata.git
-  revision: b5587588601670f762bbc79f0f4a8468064d9401
-  branch: master
-  specs:
-    identity-hostdata (0.3.3)
-      aws-sdk-s3 (~> 1.8)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -80,7 +72,6 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.30)
   dotenv
   hashie
-  identity-hostdata!
   mocha
   pry
   rack-test

--- a/app.rb
+++ b/app.rb
@@ -1,7 +1,6 @@
 require 'dotenv/load'
 require 'erb'
 require 'hashie/mash'
-require 'login_gov/hostdata'
 require 'net/http'
 require 'onelogin/ruby-saml'
 require 'pp'
@@ -13,15 +12,6 @@ require 'active_support/core_ext/object/blank'
 
 class RelyingParty < Sinatra::Base
   use Rack::Session::Cookie, key: 'sinatra_sp', secret: SecureRandom.uuid
-
-  if LoginGov::Hostdata.in_datacenter?
-    configure do
-      enable :logging
-      file = File.new("/srv/sp-saml-sinatra/shared/log/production.log", 'a+')
-      file.sync = true
-      use Rack::CommonLogger, file
-    end
-  end
 
   def init(uri)
     @auth_server_uri = uri

--- a/app.rb
+++ b/app.rb
@@ -198,7 +198,7 @@ class RelyingParty < Sinatra::Base
       raise NotImplementedError.new('Refusing to use demo cert in production')
     end
 
-    @saml_sp_certificate = ENV['sp_cert'] || File.read('config/demo_sp.key')
+    @saml_sp_certificate = ENV['sp_cert'] || File.read('config/demo_sp.crt')
   end
 
   def saml_sp_private_key
@@ -208,7 +208,7 @@ class RelyingParty < Sinatra::Base
       raise NotImplementedError.new('Refusing to use demo private key in production')
     end
 
-    @saml_sp_private_key = ENV['sp_private_key'] || File.read('config/demo_sp.crt')
+    @saml_sp_private_key = ENV['sp_private_key'] || File.read('config/demo_sp.key')
   end
 
   def running_in_prod_env?

--- a/app.rb
+++ b/app.rb
@@ -195,7 +195,7 @@ class RelyingParty < Sinatra::Base
     return @saml_sp_certificate if defined?(@saml_sp_certificate)
 
     if running_in_prod_env? && !ENV['sp_cert']
-      raise NotImplementedError.new('Refusing to use demo private key in production')
+      raise NotImplementedError.new('Refusing to use demo cert in production')
     end
 
     @saml_sp_certificate = ENV['sp_cert'] || File.read('config/demo_sp.key')
@@ -205,7 +205,7 @@ class RelyingParty < Sinatra::Base
     return @saml_sp_private_key if defined?(@saml_sp_private_key)
 
     if running_in_prod_env? && !ENV['sp_private_key']
-      raise NotImplementedError.new('Refusing to use demo cert in production')
+      raise NotImplementedError.new('Refusing to use demo private key in production')
     end
 
     @saml_sp_private_key = ENV['sp_private_key'] || File.read('config/demo_sp.crt')

--- a/app.rb
+++ b/app.rb
@@ -192,19 +192,23 @@ class RelyingParty < Sinatra::Base
   end
 
   def saml_sp_certificate
+    return @saml_sp_certificate if defined?(@saml_sp_certificate)
+
     if running_in_prod_env? && !ENV['sp_private_key']
       raise NotImplementedError.new('Refusing to use demo private key in production')
     end
 
-    ENV['sp_private_key'] || File.read('config/demo_sp.key')
+    @saml_sp_certificate = ENV['sp_private_key'] || File.read('config/demo_sp.key')
   end
 
   def saml_sp_private_key
+    return @saml_sp_private_key if defined?(@saml_sp_private_key)
+
     if running_in_prod_env? && !ENV['sp_cert']
       raise NotImplementedError.new('Refusing to use demo cert in production')
     end
 
-    ENV['sp_cert'] || File.read('config/demo_sp.crt')
+    @saml_sp_private_key = ENV['sp_cert'] || File.read('config/demo_sp.crt')
   end
 
   def running_in_prod_env?

--- a/app.rb
+++ b/app.rb
@@ -208,7 +208,7 @@ class RelyingParty < Sinatra::Base
   end
 
   def running_in_prod_env?
-    @running_in_prod_env ||- URI.parse(ENV['idp_sso_target_url']).match?(/login\.gov/)
+    @running_in_prod_env ||- URI.parse(ENV['idp_sso_target_url']).hostname.match?(/login\.gov/)
   end
 
   def idp_logout_request

--- a/app.rb
+++ b/app.rb
@@ -208,7 +208,7 @@ class RelyingParty < Sinatra::Base
   end
 
   def running_in_prod_env?
-    @running_in_prod_env ||- URI.parse(ENV['idp_sso_target_url']).match(/login\.gov/)
+    @running_in_prod_env ||- URI.parse(ENV['idp_sso_target_url']).match?(/login\.gov/)
   end
 
   def idp_logout_request

--- a/app.rb
+++ b/app.rb
@@ -194,21 +194,21 @@ class RelyingParty < Sinatra::Base
   def saml_sp_certificate
     return @saml_sp_certificate if defined?(@saml_sp_certificate)
 
-    if running_in_prod_env? && !ENV['sp_private_key']
+    if running_in_prod_env? && !ENV['sp_cert']
       raise NotImplementedError.new('Refusing to use demo private key in production')
     end
 
-    @saml_sp_certificate = ENV['sp_private_key'] || File.read('config/demo_sp.key')
+    @saml_sp_certificate = ENV['sp_cert'] || File.read('config/demo_sp.key')
   end
 
   def saml_sp_private_key
     return @saml_sp_private_key if defined?(@saml_sp_private_key)
 
-    if running_in_prod_env? && !ENV['sp_cert']
+    if running_in_prod_env? && !ENV['sp_private_key']
       raise NotImplementedError.new('Refusing to use demo cert in production')
     end
 
-    @saml_sp_private_key = ENV['sp_cert'] || File.read('config/demo_sp.crt')
+    @saml_sp_private_key = ENV['sp_private_key'] || File.read('config/demo_sp.crt')
   end
 
   def running_in_prod_env?


### PR DESCRIPTION
**Why**: So we can use non-demo certs and keys in deployed envs