### PR TITLE
Update IDP cert fingerprint for 2021 fingerprint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 export issuer=urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost
 export assertion_consumer_service_url=http://localhost:4567/consume
-export idp_sso_target_url=http://localhost:3000/api/saml/auth$(date +"%Y")
-export idp_slo_target_url=http://localhost:3000/api/saml/logout$(date +"%Y")
+export idp_sso_target_url=http://localhost:3000/api/saml/auth2021
+export idp_slo_target_url=http://localhost:3000/api/saml/logout2021
 export idp_host=localhost:3000
-export idp_cert_fingerprint=F9:D7:61:2A:11:F6:C2:74:B0:47:01:3B:B6:79:B1:53:11:C7:82:4C
+export idp_cert_fingerprint=A5:D5:63:F3:2C:E0:7E:99:6D:2C:A7:79:A6:9B:37:BE:B0:3F:6E:5E


### PR DESCRIPTION
**Why**: So that mismatch errors don't occur during signature validation in authentication response.

Generated by running the following command in [18F/identity-idp](https://github.com/18F/identity-idp):

```
openssl x509 -fingerprint -noout -in config/artifacts.example/local/saml2021.crt
```

Reverts to hard-coded years (changed to interpolated values in #76) for better future discoverability that years and fingerprint are related and must be changed together.

Separately, I'll create a task to update to newer versions of [ruby-saml](https://github.com/onelogin/ruby-saml), where it may be possible to avoid assigning the fingerprint and instead allow the gem to pull from IdP metadata endpoint via the `idp_entity_id` setting.