### PR TITLE
Push to prod cf env in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ workflows:
           matrix:
             parameters:
               space:
+                - prod
                 - staging
                 - int
                 - dev


### PR DESCRIPTION
**Why**: So that the prod env always has the latest on main