### PR TITLE
Allow user to not specify an IAL/AAl, use the SP configured values

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -36,7 +36,7 @@ class RelyingParty < Sinatra::Base
       erb :"agency/#{agency}/index", layout: false, locals: { logout_msg: logout_msg }
     else
       ial = get_param(:ial, ['sp', '1', '2', '2-strict', '0']) || '1'
-      aal = get_param(:aal, ['1', '2', '3', '3-hspd12']) || '2'
+      aal = get_param(:aal, ['sp', '1', '2', '3', '3-hspd12']) || '2'
       skip_encryption = get_param(:skip_encryption, ['true', 'false'])
 
       login_path = '/login_get?' + {
@@ -61,7 +61,7 @@ class RelyingParty < Sinatra::Base
     request = OneLogin::RubySaml::Authrequest.new
     puts "Request: #{request}"
     ial = get_param(:ial, ['sp', '1', '2', '2-strict', '0']) || '1'
-    aal = get_param(:aal, ['1', '2', '3', '3-hspd12']) || '2'
+    aal = get_param(:aal, ['sp', '1', '2', '3', '3-hspd12']) || '2'
     skip_encryption = get_param(:skip_encryption, ['true', 'false'])
     request_url = request.create(saml_settings(ial: ial, aal: aal))
     request_url += "&#{ { skip_encryption: skip_encryption }.to_query }" if skip_encryption
@@ -171,6 +171,8 @@ class RelyingParty < Sinatra::Base
       'http://idmanagement.gov/ns/assurance/aal/3'
     when '3-hspd12'
       'http://idmanagement.gov/ns/assurance/aal/3?hspd12=true'
+    else
+      nil
     end
 
     base_config.ial_context = ial_context if ial_context

--- a/app.rb
+++ b/app.rb
@@ -35,7 +35,7 @@ class RelyingParty < Sinatra::Base
       session[:agency] = agency
       erb :"agency/#{agency}/index", layout: false, locals: { logout_msg: logout_msg }
     else
-      ial = get_param(:ial, ['1', '2', '2-strict', '0']) || '1'
+      ial = get_param(:ial, ['sp', '1', '2', '2-strict', '0']) || '1'
       aal = get_param(:aal, ['1', '2', '3', '3-hspd12']) || '2'
       skip_encryption = get_param(:skip_encryption, ['true', 'false'])
 
@@ -60,7 +60,7 @@ class RelyingParty < Sinatra::Base
     puts "Logging in via GET"
     request = OneLogin::RubySaml::Authrequest.new
     puts "Request: #{request}"
-    ial = get_param(:ial, ['1', '2', '2-strict', '0']) || '1'
+    ial = get_param(:ial, ['sp', '1', '2', '2-strict', '0']) || '1'
     aal = get_param(:aal, ['1', '2', '3', '3-hspd12']) || '2'
     skip_encryption = get_param(:skip_encryption, ['true', 'false'])
     request_url = request.create(saml_settings(ial: ial, aal: aal))
@@ -152,7 +152,7 @@ class RelyingParty < Sinatra::Base
     base_config = Hashie::Mash.new(YAML.safe_load(ERB.new(template).result(binding)))
 
     ial_context = case ial
-    when nil, '', '1'
+    when '1'
       'http://idmanagement.gov/ns/assurance/ial/1'
     when '2'
       'http://idmanagement.gov/ns/assurance/ial/2'
@@ -160,6 +160,8 @@ class RelyingParty < Sinatra::Base
       'http://idmanagement.gov/ns/assurance/ial/2?strict=true'
     when '0'
       'http://idmanagement.gov/ns/assurance/ial/0'
+    else
+      nil
     end
 
     aal_context = case aal

--- a/config/saml_settings.yml
+++ b/config/saml_settings.yml
@@ -7,7 +7,6 @@ idp_cert_fingerprint: <%= ENV['idp_cert_fingerprint'] %>
 
 assertion_consumer_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 name_identifier_format: urn:oasis:names:tc:SAML:1.1:nameid-format:persistent
-ial_context: http://idmanagement.gov/ns/assurance/ial/1
 single_signon_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 allowed_clock_drift: 60
 security:

--- a/views/index.erb
+++ b/views/index.erb
@@ -111,6 +111,7 @@
                   </label>
                   <select name="ial" id="ial" class="usa-select">
                     <% [
+                      ['sp', 'ServiceProvider configured'],
                       ['1', 'IAL 1 (Default)'],
                       ['2', 'IAL  2'],
                       ['2-strict', 'IAL 2 (strict)'],

--- a/views/index.erb
+++ b/views/index.erb
@@ -93,6 +93,7 @@
                   </label>
                   <select name="aal" id="aal" class="usa-select">
                     <% [
+                      ['sp', 'ServiceProvider configured'],
                       ['1', 'AAL 1 (Default)'],
                       ['2', 'AAL 2'],
                       ['3', 'AAL 3'],


### PR DESCRIPTION
In investigating LG-4472, I found that the SP in question is not sending over _any_ authn_contexts with their auth request. This PR allows the user to do the same - not send ial and/or aal contexts, relying on the configuration of the SP.