### PR TITLE
updating to Bundler 2.20.0 in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,4 +84,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.2.20


### PR DESCRIPTION
**TL;DR**: Installs Bundler 2.20.0 in this repo, and updates version within `Gemfile.lock` accordingly, via:

```
gem install bundler:2.20.0
bundle update --bundler
```

No additional gems are affected. Hosts that build from this branch use Bundler 2.20.0 when running `rbenv exec bundle install` during build time.

Output from commands on an `idp` instance built off the `bleachbit` branch of `identity-devops`, which uses the `jp/bundler-2-electric-boogaloo` branch for all repos:

```
$ which bundler
/opt/ruby_build/shims/bundler
$ bundler -v
Bundler version 2.2.24
$ gem info bundler

*** LOCAL GEMS ***

bundler (2.2.24, 1.17.2)
    Authors: André Arko, Samuel Giddins, Colby Swandale, Hiroshi
    Shibata, David Rodríguez, Grey Baker, Stephanie Morillo, Chris
    Morris, James Wen, Tim Moore, André Medeiros, Jessica Lynn Suttles,
    Terence Lee, Carl Lerche, Yehuda Katz
    Homepage: https://bundler.io
    License: MIT
    Installed at (2.2.24): /opt/ruby_build/versions/2.6.7/lib/ruby/gems/2.6.0
                 (1.17.2, default): /opt/ruby_build/versions/2.6.7/lib/ruby/gems/2.6.0

    The best way to manage your application's dependencies
$ which ruby
/opt/ruby_build/shims/ruby
$ ruby -v
ruby 2.6.7p197 (2021-04-05 revision 67941) [x86_64-linux]
```

Addresses https://github.com/18F/identity-devops/issues/3563

Full set of Bundler 2.20.0 PRs:
- https://github.com/18F/identity-cookbooks/pull/54
- https://github.com/18F/identity-base-image/pull/159
- https://github.com/18F/identity-dashboard/pull/465
- https://github.com/18F/identity-idp-config/pull/440
- https://github.com/18F/identity-oidc-sinatra/pull/100
- https://github.com/18F/identity-saml-sinatra/pull/85