### PR TITLE
Bump the deploy container ruby version to 2.7.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7.3
     working_directory: ~/identity-saml-sinatra
     parameters:
       space:


### PR DESCRIPTION
**Why**: So the deploy container won't render errors about the wrong ruby version