### PR TITLE
Continue "make setup" if env file already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOST ?= localhost
 PORT ?= 4567
 
 .env: .env.example
-	cp -n .env.example .env
+	cp -n .env.example .env || true
 
 setup: .env
 	bundle install


### PR DESCRIPTION
Previously, if trying to run `make setup` with an existing `.env` file, it would fail at the first step:

```
$ make setup
cp -n .env.example .env
make: *** [.env] Error 1
```

We pass the `-n` flag, presumably so that an existing `.env` file isn't replaced by the example `.env` file. In those scenarios, we should allow the Makefile script to continue unencumbered.

```
$ make setup
cp -n .env.example .env || true
bundle install
...
```