### PR TITLE
Update env example 2023 endpoint cert fingerprint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ export assertion_consumer_service_url=http://localhost:4567/consume
 export idp_sso_target_url=http://localhost:3000/api/saml/auth2023
 export idp_slo_target_url=http://localhost:3000/api/saml/logout2023
 export idp_host=localhost:3000
-export idp_cert_fingerprint=A5:D5:63:F3:2C:E0:7E:99:6D:2C:A7:79:A6:9B:37:BE:B0:3F:6E:5E
+export idp_cert_fingerprint=59:54:A6:99:E4:F5:BA:33:1C:27:3C:58:32:DA:32:08:FF:C7:ED:BE


### PR DESCRIPTION
Why? The fingerprint should be kept in sync with the endpoint, otherwise there's a signature validation error when returning to the sample app from the IdP.

Follows: #122

See similar: #81

In `identity-idp`:

```bash
openssl x509 -fingerprint -noout -in config/artifacts.example/local/saml2023.crt 
# SHA1 Fingerprint=59:54:A6:99:E4:F5:BA:33:1C:27:3C:58:32:DA:32:08:FF:C7:ED:BE
```