### PR TITLE
LG-9314 Sample apps should have failure_to_proof URLs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -150,7 +150,7 @@ class RelyingParty < Sinatra::Base
 
   get '/failure_to_proof' do
     puts 'Failure to Proof :('
-    erb :failure_to_proof#, layout: true
+    erb :failure_to_proof
   end
 
   private

--- a/app.rb
+++ b/app.rb
@@ -148,6 +148,11 @@ class RelyingParty < Sinatra::Base
     end
   end
 
+  get '/failure_to_proof' do
+    puts 'Failure to Proof :('
+    erb :failure_to_proof#, layout: true
+  end
+
   private
 
   def logout_session

--- a/views/failure_to_proof.erb
+++ b/views/failure_to_proof.erb
@@ -1,8 +1,2 @@
-<div class="clearfix">
-  <div class="col-12 sm-col-6 mx-auto">
-    <div class="h5 p2 center">
-      <span class="bold caps">Failure to Proof</span>
-      <p><strong>We were unable to verify your identity</strong>.</p>
-    </div>
-  </div>
-</div>
+<h1>Failure to Proof</h1>
+<div>We were unable to verify your identity.</div>

--- a/views/failure_to_proof.erb
+++ b/views/failure_to_proof.erb
@@ -1,0 +1,8 @@
+<div class="clearfix">
+  <div class="col-12 sm-col-6 mx-auto">
+    <div class="h5 p2 center">
+      <span class="bold caps">Failure to Proof</span>
+      <p><strong>We were unable to verify your identity</strong>.</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
[LG-9314](https://cm-jira.usa.gov/browse/LG-9314)

### What
Create a route and page for failure to proof
<img width="1016" alt="saml-sinatra-failure-to-proof" src="https://user-images.githubusercontent.com/1261794/234981130-704df067-bf95-4753-8c57-ffb926a42ba2.png">

Note: this page has recently been added for the [identity-oidc-sinatra](https://github.com/18F/identity-oidc-sinatra) app
