### PR TITLE
Add z-index to popup options list

### DIFF
--- a/public/assets/css/sign-in.css
+++ b/public/assets/css/sign-in.css
@@ -39,6 +39,7 @@
   border-radius: 3px;
   padding: 10px;
   box-shadow: 0 0 10px #fff;
+  z-index: 1;
 }
 
 .details-popup .usa-select {


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/LG-9904

This change adds a z-index to the popup menu so that it covers page content.

before:
<img width="267" alt="Screen Shot 2023-06-09 at 10 13 13 AM" src="https://github.com/18F/identity-saml-sinatra/assets/5473830/c38fb2d0-4a0b-496b-9701-48569d4bc4fb">

after:
<img width="332" alt="Screen Shot 2023-06-09 at 10 11 27 AM" src="https://github.com/18F/identity-saml-sinatra/assets/5473830/f5a103f3-3781-430e-a34d-71fc61b08ac1">
