### PR TITLE
Add biometric comparison and VTR support

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -116,8 +116,11 @@
                       ['1', 'Authentication only (default)'],
                       ['2', 'Identity-verified'],
                       ['0', 'IALMax'],
+                      if ENV['vtr_enabled'] == 'true'
+                        ['biometric-comparison-required', 'Biometric Comparison']
+                      end,
                       ['step-up', 'Step-up Flow'],
-                    ].each do |value, label| %>
+                    ].compact.each do |value, label| %>
                       <option value="<%= value %>"
                               <%= 'selected="true"' if ial == value %>
                               >


### PR DESCRIPTION
We added biometric comparison to the OIDC sample app in https://github.com/18F/identity-oidc-sinatra/pull/149 and VTR support in https://github.com/18F/identity-oidc-sinatra/pull/153.

Using those implementations as a guide this commit adds both biometric comparison and VTR support to this app.