### PR TITLE
LG-12912 Rename `vtr_enabled` to `vtr_disabled`

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -193,7 +193,7 @@ class RelyingParty < Sinatra::Base
   end
 
   def ial_authn_context(ial)
-    return nil if vtr_enabled?
+    return nil unless vtr_disabled?
 
     case ial
     when '1'
@@ -208,7 +208,7 @@ class RelyingParty < Sinatra::Base
   end
 
   def aal_authn_context(aal)
-    return nil if vtr_enabled?
+    return nil unless vtr_disabled?
 
     case aal
     when '2'
@@ -223,7 +223,7 @@ class RelyingParty < Sinatra::Base
   end
 
   def vtr_authn_context(ial:, aal:)
-    return nil unless vtr_enabled?
+    return nil if vtr_disabled?
 
       values = ['C1']
 
@@ -338,8 +338,8 @@ class RelyingParty < Sinatra::Base
     ssn&.gsub(/\d/, '#')
   end
 
-  def vtr_enabled?
-    ENV['vtr_enabled'] == 'true'
+  def vtr_disabled?
+    ENV['vtr_disabled'] == 'true'
   end
 
   run! if app_file == $0

--- a/views/index.erb
+++ b/views/index.erb
@@ -116,7 +116,7 @@
                       ['1', 'Authentication only (default)'],
                       ['2', 'Identity-verified'],
                       ['0', 'IALMax'],
-                      if ENV['vtr_enabled'] == 'true'
+                      if ENV['vtr_disabled'] != 'true'
                         ['biometric-comparison-required', 'Biometric Comparison']
                       end,
                       ['step-up', 'Step-up Flow'],


### PR DESCRIPTION
The use of the VTR param has been authorized by security and is to be enabled in all environments except for prod. This commit renames the `vtr_enabled` config value that enabled the VTR param to `vtr_disabled` which does the opposite. This effectively changes the default behavior if no value is specified.

We will need to correctly set `vtr_disabled=true` in prod and enable VTR support in the IdP in all environments except prod before merging this.