### PR TITLE
Add note to Biometric Comparison that it is disabled in prod

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -116,7 +116,7 @@
                       ['1', 'Authentication only (default)'],
                       ['2', 'Identity-verified'],
                       ['0', 'IALMax'],
-                      ['biometric-comparison-required', 'Biometric Comparison']
+                      ['biometric-comparison-required', 'Biometric Comparison (Disabled in prod)'],
                       ['step-up', 'Step-up Flow'],
                     ].compact.each do |value, label| %>
                       <option value="<%= value %>"

--- a/views/index.erb
+++ b/views/index.erb
@@ -116,9 +116,7 @@
                       ['1', 'Authentication only (default)'],
                       ['2', 'Identity-verified'],
                       ['0', 'IALMax'],
-                      if ENV['vtr_disabled'] != 'true'
-                        ['biometric-comparison-required', 'Biometric Comparison']
-                      end,
+                      ['biometric-comparison-required', 'Biometric Comparison']
                       ['step-up', 'Step-up Flow'],
                     ].compact.each do |value, label| %>
                       <option value="<%= value %>"


### PR DESCRIPTION
The biometric comparison feature has been enabled in all environments except for prod. We want to ensure that no partners see it enabled in int and try to use it in their apps which will not work when they are promoted in prod. This commit helps with that by adding a warning label to the "Biometric comparison" option on this sample app.