### PR TITLE
Add support for IALMax using multiple vectors of trust

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -225,20 +225,25 @@ class RelyingParty < Sinatra::Base
   def vtr_authn_context(ial:, aal:)
     return nil if vtr_disabled?
 
-      values = ['C1']
+    values = ['C1']
 
-      values << {
-        '2' => 'C2',
-        '2-phishing_resistant' => 'C2.Ca',
-        '2-hspd12' => 'C2.Cb',
-      }[aal]
+    values << {
+      '2' => 'C2',
+      '2-phishing_resistant' => 'C2.Ca',
+      '2-hspd12' => 'C2.Cb',
+    }[aal]
 
-      values << {
-        '2' => 'P1',
-        'biometric-comparison-required' => 'P1.Pb',
-      }[ial]
+    values << {
+      '2' => 'P1',
+      'biometric-comparison-required' => 'P1.Pb',
+    }[ial]
 
-      values.compact.join('.')
+    vtr_list = [values.compact.join('.')]
+    if ial == '0'
+      proofing_vector = values.dup + ['P1']
+      vtr_list = [proofing_vector.compact.join('.'), *vtr_list]
+    end
+    vtr_list
   end
 
   def saml_sp_certificate


### PR DESCRIPTION
Support for IALMax using vectors of trust was added to the OIDC sample app in https://github.com/18F/identity-oidc-sinatra/pull/163. This commit applies the same change to this app.

There is also some whitespace cleanup in here since I discovered some code that was not properly indented.