### PR TITLE
update to 2024 certs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 export issuer=urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost
 export assertion_consumer_service_url=http://localhost:4567/consume
-export idp_sso_target_url=http://localhost:3000/api/saml/auth2023
-export idp_slo_target_url=http://localhost:3000/api/saml/logout2023
+export idp_sso_target_url=http://localhost:3000/api/saml/auth2024
+export idp_slo_target_url=http://localhost:3000/api/saml/logout2024
 export idp_host=localhost:3000
-export idp_cert_fingerprint=59:54:A6:99:E4:F5:BA:33:1C:27:3C:58:32:DA:32:08:FF:C7:ED:BE
+export idp_cert_fingerprint=EF:54:67:D4:32:C7:52:E9:8C:25:22:EF:4D:65:4D:08:C9:9A:D8:DC


### PR DESCRIPTION
Update env.example to use 2024 certs.
This also required updating the fingerprint for that X509 certificate.