### PR TITLE
Properly include VTR authn context

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -181,7 +181,7 @@ class RelyingParty < Sinatra::Base
     base_config.authn_context = [
       base_config.ial_context,
       base_config.aal_context,
-      base_config.vtr_context,
+      *base_config.vtr_context,
       'http://idmanagement.gov/ns/requested_attributes?ReqAttr=x509_presented',
     ].compact
     base_config.force_authn = force_authn


### PR DESCRIPTION
In #148 I added support for IALMax using VTR. This commit caused the `vtr` function to start returning an array instead of a string. That was not properly handled in the code that added the VTR authn contexts. This commit fixes that issue.

This was not caught by tests because there are no tests.