### PR TITLE
Update NameID format to match expected value

### DIFF
--- a/config/saml_settings.yml
+++ b/config/saml_settings.yml
@@ -6,7 +6,7 @@ idp_slo_target_url: <%= ENV['idp_slo_target_url'] %>
 idp_cert_fingerprint: <%= ENV['idp_cert_fingerprint'] %>
 
 assertion_consumer_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
-name_identifier_format: urn:oasis:names:tc:SAML:1.1:nameid-format:persistent
+name_identifier_format: urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
 single_signon_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 allowed_clock_drift: 60
 security:


### PR DESCRIPTION
In https://github.com/18F/identity-idp/pull/10629 we updated the validation of NameID formats and apparently this application is using an invalid one. This commit updates it to use a valid NameID format.